### PR TITLE
fix: bundle VAAPI/QSV driver packages in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,19 @@ WORKDIR /app
 
 COPY --chown=node:node scripts/verify-ffmpeg.mjs scripts/smoke-ffmpeg-transcode.mjs scripts/smoke-ffmpeg-hardware.mjs scripts/verify-nodeav-probe.mjs scripts/verify-runtime.mjs ./scripts/
 
+# ffmpeg plus hardware acceleration drivers: Mesa VA-API drivers (AMD/others)
+# on all architectures; Intel VAAPI (iHD) and the Intel VPL GPU runtime (QSV)
+# on amd64, the only architecture Debian ships them for. Without these the
+# advertised vaapi/qsv hardware modes fail at runtime inside the container.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg \
+    && apt-get install -y --no-install-recommends \
+       ffmpeg \
+       mesa-va-drivers \
+    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+         apt-get install -y --no-install-recommends \
+           intel-media-va-driver \
+           libmfx-gen1.2; \
+       fi \
     && rm -rf /var/lib/apt/lists/* \
     && node scripts/verify-ffmpeg.mjs
 

--- a/docs/transcoding-runtime.md
+++ b/docs/transcoding-runtime.md
@@ -14,7 +14,7 @@ Direct play stays the preferred path when the selected file is already compatibl
 - Keep temporary playback artifact storage on fast local disk. Per-session virtual playlists live under `playback-sessions/<sessionId>/`, and shared encoded segments live under `playback-cache/<cacheKey>/` in the configured Lunarr data directory.
 - Keep remote libraries (SFTP and WebDAV) seekable by preserving remote file size and duration metadata. Non-direct remote playback streams through Lunarr's private localhost range proxy into FFmpeg, not by exposing remote credentials to FFmpeg.
 
-The Docker runtime image installs system FFmpeg and runs the baseline FFmpeg playback verifier plus the NodeAV probe verifier during image build.
+The Docker runtime image installs system FFmpeg and runs the baseline FFmpeg playback verifier plus the NodeAV probe verifier during image build. The image also bundles the Mesa VA-API drivers (`mesa-va-drivers`, used by AMD) on all architectures, and on amd64 the Intel VAAPI driver (`intel-media-va-driver`) plus the Intel VPL GPU runtime for QSV (`libmfx-gen1.2`), so `vaapi` and `qsv` hardware modes work once the host device is mounted into the container.
 
 ## Playback Behavior
 


### PR DESCRIPTION
## Problem

The published Docker image installs only `ffmpeg` with `--no-install-recommends` (`Dockerfile`), so it ships **no hardware-acceleration driver backends at all** (no `iHD_drv_video.so`, no Mesa `*_drv_video.so`, no VPL runtime). The documented and UI-selectable `vaapi`/`qsv` hardware modes therefore fail at runtime even when `/dev/dri` is correctly mounted into the container:

- **VAAPI:** `Failed to set value 'vaapi=hw:/dev/dri/renderD128' for option 'init_hw_device': Input/output error`
- **QSV:** `Failed to set value 'qsv=hw,child_device=/dev/dri/renderD128' for option 'init_hw_device': Unknown error occurred`
- `docker exec lunarr node scripts/smoke-ffmpeg-hardware.mjs` crashes with a stack trace

This goes unnoticed because the build-time verifier only checks software encoding (`verify-ffmpeg.mjs` runs during image build and passes), while the hardware smoke is host-gated and can't run in CI (no GPU on runners).

## Fix

Install the driver packages alongside `ffmpeg` in the runtime image:

| Package | Provides | Architectures |
| --- | --- | --- |
| `mesa-va-drivers` | AMD/other VA-API drivers | all (installed unconditionally) |
| `intel-media-va-driver` | Intel VAAPI (iHD) | amd64 only in Debian → installed conditionally |
| `libmfx-gen1.2` | Intel VPL GPU runtime → QSV | amd64 only in Debian → installed conditionally |

The Intel packages do not exist for arm64 in trixie (verified against the Debian archive indices), so they are installed only when `dpkg --print-architecture` is `amd64` — this keeps the multi-arch (amd64/arm64) release builds working. NVIDIA/NVENC is unaffected either way (host-driver injection via the NVIDIA container toolkit, as before).

Image size grows 1.13 GB → 1.16 GB (+~30 MB). `docs/transcoding-runtime.md` now notes that the image bundles these drivers.

## Verification

Tested on a real Intel host (i5-13600K, `/dev/dri` mounted, Unraid) from a **pristine image built from this branch** (`docker build`, no manual changes inside the container):

- `FFMPEG_SMOKE_HARDWARE=vaapi node scripts/smoke-ffmpeg-hardware.mjs` → **passed** (previously: init I/O error)
- `FFMPEG_SMOKE_HARDWARE=qsv node scripts/smoke-ffmpeg-hardware.mjs` → **passed** (previously: init error)
- `LUNARR_VERIFY_HARDWARE=auto node scripts/verify-runtime.mjs` → **passed** (auto detects vaapi)
- Real-world transcode, 4K HEVC 10-bit → 1080p H.264 via VAAPI: **319 fps / 13.3x realtime** (previously failed at device init)

Checks run on the branch: `bun run check` (0 errors, 0 warnings), `bun run build`, `bun run test` (1010 tests, **0 failures**; 3 unrelated environmental errors caused by a stray `/tmp/dotnet-diagnostic-*` socket from another process on the contributor machine), `bun run verify:ffmpeg`.

Not tested: AMD hardware (none available — `mesa-va-drivers` is the standard package for it and installs with no additional dependencies) and the arm64 image build itself (no arm64 emulator available here; package availability for arm64 was verified against the Debian archive indices, and the conditional install path was exercised in a clean `debian:trixie-slim` container). The amd64 image was rebuilt from the final Dockerfile and both hardware smokes re-verified after the multi-arch restructure.